### PR TITLE
Use `registerPlugin` instead of deprecated `plugin`

### DIFF
--- a/lib/videojs-Background.js
+++ b/lib/videojs-Background.js
@@ -125,5 +125,5 @@
   }
 
   // register the plugin
-  videojs.plugin('Background', Background);
+  videojs.registerPlugin('Background', Background);
 })(window, window.videojs);


### PR DESCRIPTION
Just updating the call to `plugin` to use `registerPlugin`, since the former is deprecated in VideoJS 6: https://github.com/videojs/video.js/wiki/Video.js-6-Migration-Guide#videojsplugin